### PR TITLE
Readme file updated to reflect valid text-shadow css property values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,11 @@ If a default shadow is provided, it will be used for the non-suffixed `.text-sha
 module.exports = {
   theme: {
     textShadow: {
-      default: '0 1px 3px 0 rgba(0, 0, 0, .1), 0 1px 2px 0 rgba(0, 0, 0, .06)',
-      md: ' 0 4px 6px -1px rgba(0, 0, 0, .1), 0 2px 4px -1px rgba(0, 0, 0, .06)',
-      h1: ' 0 10px 15px -3px rgba(0, 0, 0, .1), 0 4px 6px -2px rgba(0, 0, 0, .05)',
-      xl: ' 0 20px 25px -5px rgba(0, 0, 0, .1), 0 10px 10px -5px rgba(0, 0, 0, .04)',
-      '2xl': '0 25px 50px -12px rgba(0, 0, 0, .25)',
-      brand: '0 35px 60px -15px rgba(0, 0, 0, .3)',
-      outline: '0 0 0 3px rgba(66,153,225,0.5)',
-      focus: '0 0 0 3px rgba(66,153,225,0.5)',
-      'none': 'none',
+      default: '0 2px 0 #000',
+      md: '0 2px 2px #000',
+      h1: '0 0 3px #FF0000, 0 0 5px #0000FF',
+      xl: '0 0 3px rgba(0, 0, 0, .8), 0 0 5px rgba(0, 0, 0, .9)',
+      none: 'none',
     }
   }
 }


### PR DESCRIPTION
Hi, 

I've updated the readme file with valid text-shadow css values. The readme contained a copy of box-shadow css properties from the Tailwindcss site, which is not compatible with the text-shadow property. I actually changed the values to something bit more sensible but I've kept the rgba example. 

I think the keys should make a bit more sense but that's just a technicality in my opinion. 

Cizza