### PR TITLE
Adds lodash dependency for Yarn v2 compatability

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "homepage": "https://github.com/iunteq/tailwindcss-textshadow#readme",
   "dependencies": {
+    "lodash": "^4.17.21",
     "tailwindcss": "^1.2.0"
   }
 }


### PR DESCRIPTION
Unless lodash is specified as an explicit dependency, Yarn v2 gives the following error:

`Error: tailwindcss-textshadow tried to access lodash, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.`